### PR TITLE
Avoid command line too long error when globbing genome files

### DIFF
--- a/download-ncbi-genomes
+++ b/download-ncbi-genomes
@@ -56,7 +56,7 @@ function download_specific_lib {
       cat ftpfilepaths | xargs -P ${PARALLEL} -n 1 wget -c -nv
 
       echo -n "Download complete. Unpacking files ... "
-      gunzip *.gz
+      find -maxdepth 1 -name '*.gz' -type f -print0 | xargs -0 -P ${PARALLEL} gunzip
 
       rm -f ftpdirpaths*
       rm -f ftpfilepaths*


### PR DESCRIPTION
While running `metacache-build-refseq small` I got an error after downloading all of bacteria, because doing `*.gz` leads to a command line too long on my system.

This should fix it. Note, I added parallelization.