### PR TITLE
Ensure metacache-build-refseq works from any directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ If you *don't* have the zlib compression library installed and/or want *don't* w
 
 
 #### Building the Default RefSeq Database
-Use the ```metacache-build-refseq``` script to build a MetaCache database based on complete bacterial, viral and archaea genomes from the latest NCBI RefSeq release. Note that the genomes will be downloaded first, which can take some time.
+
+Use the `metacache-build-refseq` script to build a MetaCache database based on complete bacterial, viral and archaea genomes from the latest NCBI RefSeq release. Note that the genomes will be downloaded first, which can take some time.
+The database files are put into the folder `genomes` in the current working directory.
 
 ### [Building Custom Databases...](docs/building.md)
 

--- a/docs/mode_query.txt
+++ b/docs/mode_query.txt
@@ -343,7 +343,7 @@ EXAMPLES
     Query all sequences in multiple files against database 'refseq':
         metacache query refseq reads1.fna reads2.fna reads3.fna
 
-    Query all sequence files in folder 'test' againgst database 'refseq':
+    Query all sequence files in folder 'test' against database 'refseq':
         metacache query refseq test
 
     Query multiple files and folder contents against database 'refseq':

--- a/metacache-build-refseq
+++ b/metacache-build-refseq
@@ -31,16 +31,19 @@ if [ $# -lt 1 ]; then
   echo "Usage:    $0 (big|standard|small)"
 fi
 
+# Get the path to this executable
+scriptpath="$(readlink -nf "$0")"
+scriptdir="$(dirname "$scriptpath")"
 
 # download-ncbi-genomes <sublibrary> <target folder>
-./download-ncbi-genomes refseq/bacteria genomes
-./download-ncbi-genomes refseq/viral genomes
-./download-ncbi-genomes refseq/archaea genomes
+"$scriptdir"/download-ncbi-genomes refseq/bacteria genomes
+"$scriptdir"/download-ncbi-genomes refseq/viral genomes
+"$scriptdir"/download-ncbi-genomes refseq/archaea genomes
 
 
 # download-ncbi-taxonomy <target folder>
 ./download-ncbi-taxonomy genomes/taxonomy
-# ./download-ncbi-taxmaps  genomes/taxonomy
+# ./download-ncbi-taxmaps genomes/taxonomy
 
 
 case "$MODE" in


### PR DESCRIPTION
Fixes #46 

Changed script paths to use the metacache-build-refseq directory.

